### PR TITLE
fix: typo in url for github repo star button

### DIFF
--- a/app/dashboard/src/constants/Project.ts
+++ b/app/dashboard/src/constants/Project.ts
@@ -1,3 +1,3 @@
-export const REPO_URL = 'https://github.com/khodedawosh/Marzneshin';
+export const REPO_URL = 'https://github.com/khodedawsh/Marzneshin';
 export const ORGANIZATION_URL = 'https://github.com/khodedawosh';
 export const DONATION_URL = 'https://github.com/khodedawosh/Marzneshin#donation';


### PR DESCRIPTION
Fixing the typo in URL for GitHub button start 

- #31 