### PR TITLE
chore: ignore the modules directives warn while building

### DIFF
--- a/app/dashboard/vite.config.ts
+++ b/app/dashboard/vite.config.ts
@@ -6,6 +6,17 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  build: {
+    chunkSizeWarningLimit: 100,
+    rollupOptions: {
+      onwarn(warning, warn) {
+        if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+          return
+        }
+        warn(warning)
+      }
+    }
+  },
   plugins: [
     tsconfigPaths(),
     react({


### PR DESCRIPTION
### Objective

- Remove the cluttering warns while building in dashboard build pipeline job 

### Changes

- Vite config update: Ignore `Module level directives cause errors when bundled, 'use client'` warn
