### PR TITLE
improv(hosts-page): correct refetching, callout, pre-selecting at page startup 

### DIFF
--- a/app/dashboard/index.html
+++ b/app/dashboard/index.html
@@ -1,41 +1,26 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Marzban</title>
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="/favicon/apple-touch-icon.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="/favicon/favicon-32x32.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="/favicon/favicon-16x16.png"
-    />
-    <link rel="manifest" href="/favicon/site.webmanifest" />
-    <link
-      rel="mask-icon"
-      href="/favicon/safari-pinned-tab.svg"
-      color="#5bbad5"
-    />
-    <link rel="shortcut icon" href="/favicon/favicon.ico" />
-    <meta name="apple-mobile-web-app-title" content="Marzban" />
-    <meta name="application-name" content="Marzban" />
-    <meta name="msapplication-TileColor" content="#2b5797" />
-    <meta name="msapplication-config" content="/favicon/browserconfig.xml" />
-    <meta name="theme-color" content="#3B81F6" />
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/index.tsx"></script>
-  </body>
+<html lang="en-us">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Marzban</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />
+  <link rel="manifest" href="/favicon/site.webmanifest" />
+  <link rel="mask-icon" href="/favicon/safari-pinned-tab.svg" color="#5bbad5" />
+  <link rel="shortcut icon" href="/favicon/favicon.ico" />
+  <meta name="apple-mobile-web-app-title" content="Marzban" />
+  <meta name="application-name" content="Marzban" />
+  <meta name="msapplication-TileColor" content="#2b5797" />
+  <meta name="msapplication-config" content="/favicon/browserconfig.xml" />
+  <meta name="theme-color" content="#3B81F6" />
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/index.tsx"></script>
+</body>
+
 </html>

--- a/app/dashboard/index.html
+++ b/app/dashboard/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Marzban</title>
+  <title>Marzneshin</title>
   <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />

--- a/app/dashboard/public/locales/en.json
+++ b/app/dashboard/public/locales/en.json
@@ -87,7 +87,7 @@
     "total": "Total"
   },
   "noInboundsCallout": {
-    "header": "Nodes is not configured",
+    "header": "Configure Nodes!",
     "body": "Please configure nodes to access inbounds hosts"
   },
   "userDialog": {

--- a/app/dashboard/public/locales/en.json
+++ b/app/dashboard/public/locales/en.json
@@ -208,12 +208,16 @@
     "host.wildcard": "Use <badge>*</badge> to generate a random string (works for wildcard domain names)"
   },
   "revoke": "Revoke",
-  "deleteNode.title": "Delete Node",
-  "deleteNode.prompt": "Are you sure you want to delete the <b>{{name}}</b> node?",
-  "deleteNode.deleteSuccess": "Node {{name}} removed successfully",
-  "deleteService.title": "Delete Service",
-  "deleteService.prompt": "Are you sure you want to delete the <b>{{name}}</b> node?",
-  "deleteService.deleteSuccess": "Service {{name}} removed successfully",
+  "deleteNode": {
+    "title": "Delete Node",
+    "prompt": "Are you sure you want to delete the <b>{{name}}</b> node?",
+    "deleteSuccess": "Node {{name}} removed successfully"
+  },
+  "deleteService": {
+    "title": "Delete Service",
+    "prompt": "Are you sure you want to delete the <b>{{name}}</b> node?",
+    "deleteSuccess": "Service {{name}} removed successfully"
+  },
   "users": "Users",
   "active": "active",
   "disabled": "disabled",

--- a/app/dashboard/public/locales/en.json
+++ b/app/dashboard/public/locales/en.json
@@ -86,6 +86,10 @@
     "port": "Port",
     "total": "Total"
   },
+  "noInboundsCallout": {
+    "header": "Nodes is not configured",
+    "body": "Please configure nodes to access inbounds hosts"
+  },
   "userDialog": {
     "dataLimit": "Data Limit",
     "periodicUsageReset": "Periodic Usage Reset",

--- a/app/dashboard/src/components/callout/index.tsx
+++ b/app/dashboard/src/components/callout/index.tsx
@@ -9,12 +9,12 @@ type CalloutProps = {
 };
 
 export const Callout: FC<CalloutProps & ChakraProps> = ({ header, body, ...props }) => {
-    return (
-        <Box bg="gray.50" _dark={{ bg: 'gray.700' }} borderRadius="10" borderColor="red.500" border="2px" p="4" {...props}>
-            <Text fontSize="xl" fontWeight="bold">
-                {header}
-            </Text>
-            {body}
-        </Box>
-    )
+  return (
+    <Box bg="gray.50" _dark={{ bg: 'gray.700' }} borderRadius="10" borderColor="red.500" border="2px" p="4" {...props}>
+      <Text fontSize="xl" fontWeight="bold">
+        {header}
+      </Text>
+      {body}
+    </Box>
+  )
 }

--- a/app/dashboard/src/components/callout/index.tsx
+++ b/app/dashboard/src/components/callout/index.tsx
@@ -1,0 +1,20 @@
+
+
+import { Box, ChakraProps, Text } from '@chakra-ui/react'
+import { FC } from 'react'
+
+type CalloutProps = {
+    header: string,
+    body: string,
+};
+
+export const Callout: FC<CalloutProps & ChakraProps> = ({ header, body, ...props }) => {
+    return (
+        <Box bg="gray.50" _dark={{ bg: 'gray.700' }} borderRadius="10" borderColor="red.500" border="2px" p="4" {...props}>
+            <Text fontSize="xl" fontWeight="bold">
+                {header}
+            </Text>
+            {body}
+        </Box>
+    )
+}

--- a/app/dashboard/src/pages/hosts/container.tsx
+++ b/app/dashboard/src/pages/hosts/container.tsx
@@ -5,6 +5,8 @@ import { queryIds } from 'constants/query-ids';
 import { useQuery } from '@tanstack/react-query';
 import { fetchInbounds, fetchInboundHosts, useInbounds } from 'stores';
 import { Grid, GridItem, } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
+import { Callout } from 'components/callout';
 
 export const InboundsHostsManager = () => {
   const { selectedInbound } = useInbounds();
@@ -25,21 +27,26 @@ export const InboundsHostsManager = () => {
     }
   });
 
-  return (
-    <>
-      <InboundsHostsFilters />
-      <Grid
-        templateColumns='repeat(4, 1fr)'
-        gap="3"
-        h="10rem"
-      >
-        <GridItem colSpan={1}>
-          <InboundsSidebar inbounds={inbounds} />
-        </GridItem>
-        <GridItem colSpan={3}>
-          <HostsTable hosts={hosts} />
-        </GridItem>
-      </Grid>
-    </>
-  )
+  const { t } = useTranslation('noInboundsCallout');
+
+  return inbounds.length === 0 ?
+    <Callout header={t('noInboundsCallout.header')} body={t('noInboundsCallout.body')} />
+    : (
+      <>
+        <InboundsHostsFilters />
+        <Grid
+          templateColumns='repeat(4, 1fr)'
+          gap="3"
+          h="10rem"
+        >
+          <GridItem colSpan={1}>
+            <InboundsSidebar inbounds={inbounds} />
+          </GridItem>
+          <GridItem colSpan={3}>
+            <HostsTable hosts={hosts} />
+          </GridItem>
+        </Grid>
+      </>
+
+    )
 }

--- a/app/dashboard/src/pages/hosts/dialog/default-values.ts
+++ b/app/dashboard/src/pages/hosts/dialog/default-values.ts
@@ -3,7 +3,7 @@ export const getDefaultValues = (): HostSchema => {
   return {
     host: '',
     sni: '',
-    port: 1,
+    port: null,
     path: '',
     address: '',
     remark: '',

--- a/app/dashboard/src/pages/hosts/dialog/index.tsx
+++ b/app/dashboard/src/pages/hosts/dialog/index.tsx
@@ -104,7 +104,7 @@ export const HostsDialog: FC = () => {
       .then(() => {
         toast({
           title: t(
-            isEditingHost ? 'hostsDialog.editHost' : 'hostsDialog.createNewHost',
+            isEditingHost ? 'hostsDialog.editHost' : 'hostsDialog.createHost',
             { hoshtName: values.host }
           ),
           status: 'success',

--- a/app/dashboard/src/pages/hosts/inbounds-sidebar/index.tsx
+++ b/app/dashboard/src/pages/hosts/inbounds-sidebar/index.tsx
@@ -4,6 +4,7 @@ import { InboundCard } from 'components/inbounds-card';
 import { handleSort } from 'components/table';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useEffect } from 'react';
 import { useInbounds } from 'stores';
 import { InboundType } from 'types';
 
@@ -22,6 +23,9 @@ export const InboundsSidebar: FC<InboundsSidebarProps> = ({
     refetchHosts,
   } = useInbounds();
 
+  useEffect(() => {
+    selectedInbound === undefined && selectInbound(inbounds[0]);
+  }, [selectedInbound, inbounds]);
 
   const { t } = useTranslation();
 

--- a/app/dashboard/src/pages/nodes/dialog.tsx
+++ b/app/dashboard/src/pages/nodes/dialog.tsx
@@ -210,7 +210,6 @@ export const NodesDialog: FC = () => {
                         aria-label="delete node"
                         onClick={() => {
                           if (editingNode !== null) {
-                            console.log('deleting')
                             onDeletingNode(editingNode);
                             onClose();
                           }

--- a/app/dashboard/src/stores/inbounds.store.ts
+++ b/app/dashboard/src/stores/inbounds.store.ts
@@ -132,7 +132,10 @@ export const useInbounds = create(
       if (hostId !== undefined) {
         useDashboard.setState({ loading: true });
         return fetch(`/inbounds/hosts/${hostId}`, { method: 'PUT', body })
-          .then(() => true)
+          .then(() => {
+            get().refetchHosts();
+            return true;
+          })
           .catch(() => false)
           .finally(() => {
             useDashboard.setState({ loading: false });
@@ -146,7 +149,10 @@ export const useInbounds = create(
       if (inboundId !== undefined) {
         useDashboard.setState({ loading: true });
         return fetch(`/inbounds/${inboundId}/hosts`, { method: 'POST', body })
-          .then(() => true)
+          .then(() => {
+            get().refetchHosts();
+            return true;
+          })
           .catch(() => false)
           .finally(() => {
             useDashboard.setState({ loading: false });
@@ -159,7 +165,10 @@ export const useInbounds = create(
     deleteHost: async (hostId: number): Promise<boolean> => {
       useDashboard.setState({ loading: true });
       return fetch(`/inbounds/hosts/${hostId}`, { method: 'DELETE' })
-        .then(() => true)
+        .then(() => {
+          get().refetchHosts();
+          return true;
+        })
         .catch(() => false)
         .finally(() => {
           useDashboard.setState({ loading: false });

--- a/app/dashboard/src/stores/inbounds.store.ts
+++ b/app/dashboard/src/stores/inbounds.store.ts
@@ -14,7 +14,8 @@ export const hostSchema = z.object({
   address: z.string().min(1, 'Address is required'),
   port: z.coerce.number()
     .gte(1, 'Port must be more than 1')
-    .lte(65535, 'Port can not be more than 65535'),
+    .lte(65535, 'Port can not be more than 65535')
+    .or(z.string().nullable()),
   path: z.string(),
   sni: z.string(),
   host: z.string(),

--- a/app/dashboard/src/stores/inbounds.store.ts
+++ b/app/dashboard/src/stores/inbounds.store.ts
@@ -133,13 +133,11 @@ export const useInbounds = create(
       if (hostId !== undefined) {
         useDashboard.setState({ loading: true });
         return fetch(`/inbounds/hosts/${hostId}`, { method: 'PUT', body })
-          .then(() => {
-            get().refetchHosts();
-            return true;
-          })
+          .then(() => true)
           .catch(() => false)
           .finally(() => {
             useDashboard.setState({ loading: false });
+            get().refetchHosts();
           });
       }
     },
@@ -150,13 +148,11 @@ export const useInbounds = create(
       if (inboundId !== undefined) {
         useDashboard.setState({ loading: true });
         return fetch(`/inbounds/${inboundId}/hosts`, { method: 'POST', body })
-          .then(() => {
-            get().refetchHosts();
-            return true;
-          })
+          .then(() => true)
           .catch(() => false)
           .finally(() => {
             useDashboard.setState({ loading: false });
+            get().refetchHosts();
           });
       }
     },

--- a/makefile
+++ b/makefile
@@ -14,16 +14,15 @@ dashboard-dev:
 	VITE_BASE_API=http://0.0.0.0:8000/api/ npm run dev \
 		--prefix './app/dashboard/' \
     	-- --host 0.0.0.0 \
-    	--base ./app/dashboard/ \
+    	--base /dashboard/ \
     	--clearScreen false
 
 dashboard-preview:
 	VITE_BASE_API=http://0.0.0.0:8000/api/ npm run preview \
 		--prefix './app/dashboard/' \
     	-- --host 0.0.0.0 \
-    	--base ./app/dashboard/ \
+    	--base /dashboard/ \
     	--clearScreen false
-
 
 dashboard-cleanup:
 	rm -rf app/dashboard/node_modules/


### PR DESCRIPTION
### Changes Made

- Auto-Selection of First Inbound: Implemented a feature to automatically select the first inbound at the start if no inbound is selected.

- Refetch Hosts on Creation and Deletion: Modified the logic to refetch hosts once a host is created or deleted. This ensures that the latest data is always displayed on the hosts page.

- Toast Message Consistency: Ensured consistency in the toast message when a host is created. Reused the same message for a cleaner user experience.

- Callout for No Inbounds: Added a callout to notify users when there are no inbounds, providing a clearer indication of the page status.