### PR TITLE
fix: show links also when users are on hold

### DIFF
--- a/app/templates/subscription/index.html
+++ b/app/templates/subscription/index.html
@@ -91,7 +91,7 @@
         remaining)
         {% endif %}</p>
 
-    {% if user.status == 'active' %}
+    {% if user.status == 'active' or user.status == 'on_hold' %}
     <h2>Links:</h2>
     <ul>
         {% for link in links %}


### PR DESCRIPTION
v2ray links should show up when user status is on hold