### PR TITLE
fix: update v2share to fix incorrect vmess url

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ python-multipart==0.0.7
 xxhash==3.4.1
 grpcio==1.60.0
 psycopg==3.1.18
-v2share==0.1.0a5
+v2share==0.1.0a6


### PR DESCRIPTION
fix a problem in vmess urls by updating v2share