### PR TITLE
fix(remove-settings-for-none-sudo): removign settings button on mobile for non-sudo admin

### DIFF
--- a/dashboard/src/features/bottom-menu/index.tsx
+++ b/dashboard/src/features/bottom-menu/index.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { FC } from "react";
 import { Box, Home, Server, ServerCog, UsersIcon } from 'lucide-react';
 import { useIsCurrentRoute } from "@marzneshin/hooks";
+import { cn } from "@marzneshin/utils";
 
 type BottomMenuItemProps = Omit<SidebarItem, 'isParent' | 'subItem'>
 
@@ -63,7 +64,7 @@ export const DashboardBottomMenu = ({ variant = "admin" }: { variant: "sudo-admi
     const { isCurrentRouteActive } = useIsCurrentRoute()
     const items = variant === "sudo-admin" ? sudoAdminItems : adminItems;
     return (
-        <div className="w-full flex flex-row justify-between items-center">
+        <div className={cn("w-full flex flex-row  items-center", variant == "admin" ? "justify-evenly" : "justify-between")}>
             {items.map((item: BottomMenuItemProps) => (
                 <BottomMenuItem
                     active={isCurrentRouteActive(item.to)}

--- a/dashboard/src/features/entity-table/components/sidebar-entity-selection.tsx
+++ b/dashboard/src/features/entity-table/components/sidebar-entity-selection.tsx
@@ -38,29 +38,27 @@ export const SidebarEntitySelection = () => {
                 </TableRow>
             </TableHeader>
             <TableBody>
-                <ScrollArea className="w-full h-full p-2">
-                    <ToggleGroup
-                        type="single"
-                        onValueChange={(value) => setSidebarEntityId(value ==="" ? undefined : value)}
-                        defaultValue={String(sidebarEntityId)}
-                    >
-                        <div className="flex flex-col w-full gap-2">
-                            {sidebarEntities.map((entity: any) => (
-                                <ToggleGroupItem
-                                    className="px-0 w-full h-full"
-                                    value={String(entity.id)}
-                                    key={String(entity.id)}
-                                    id={String(entity.id)}>
-                                    <SidebarEntityCard
-                                        {...sidebarCardProps}
-                                        entity={entity}
-                                        checked={sidebarEntityId === String(entity.id)}
-                                    />
-                                </ToggleGroupItem>
-                            ))}
-                        </div>
-                    </ToggleGroup>
-                </ScrollArea>
+                <ToggleGroup
+                    type="single"
+                    onValueChange={(value) => setSidebarEntityId(value === "" ? undefined : value)}
+                    defaultValue={String(sidebarEntityId)}
+                >
+                    <ScrollArea className="flex flex-col justify-start p-1 gap-3 h-full max-h-[20rem]">
+                        {sidebarEntities.map((entity: any) => (
+                            <ToggleGroupItem
+                                className="px-0 w-full h-full"
+                                value={String(entity.id)}
+                                key={String(entity.id)}
+                                id={String(entity.id)}>
+                                <SidebarEntityCard
+                                    {...sidebarCardProps}
+                                    entity={entity}
+                                    checked={sidebarEntityId === String(entity.id)}
+                                />
+                            </ToggleGroupItem>
+                        ))}
+                    </ScrollArea>
+                </ToggleGroup>
             </TableBody>
         </Table>
     )

--- a/dashboard/src/routes/_dashboard.tsx
+++ b/dashboard/src/routes/_dashboard.tsx
@@ -39,27 +39,28 @@ export const DashboardLayout = () => {
     return (
         <div className="flex flex-col w-screen h-screen">
             <Header
-                start={isDesktop ? (
+                start={
                     <>
-
                         <Link to="/">
                             <HeaderLogo />
                         </Link>
-                        <ToggleButton
-                            collapsed={collapsed}
-                            onToggle={toggleCollapse}
-                        />
+                        {isDesktop && (
+
+                            <ToggleButton
+                                collapsed={collapsed}
+                                onToggle={toggleCollapse}
+                            />
+                        )}
                     </>
-                ) : (
-                    <Link to="/settings">
-                        <Settings className="bg-gray-800 text-secondary dark:hover:bg-secondary-foreground dark:hover:text-secondary dark:text-secondary-foreground size-10 rounded-md text-2xl p-2" />
-                    </Link>
-                )
                 }
                 center={<CommandBox />}
                 end={
                     <>
                         <GithubRepo variant={isDesktop ? "full" : "mini"} />
+                        {!(isDesktop && isSudo) && (<Link to="/settings">
+                            <Settings className="bg-gray-800 text-secondary dark:hover:bg-secondary-foreground dark:hover:text-secondary dark:text-secondary-foreground size-10 rounded-md text-2xl p-2" />
+                        </Link>
+                        )}
                         <HeaderMenu />
                     </>
                 }

--- a/dashboard/src/routes/_dashboard.tsx
+++ b/dashboard/src/routes/_dashboard.tsx
@@ -57,7 +57,7 @@ export const DashboardLayout = () => {
                 end={
                     <>
                         <GithubRepo variant={isDesktop ? "full" : "mini"} />
-                        {!(isDesktop && isSudo) && (<Link to="/settings">
+                        {(!isDesktop && isSudo()) && (<Link to="/settings">
                             <Settings className="bg-gray-800 text-secondary dark:hover:bg-secondary-foreground dark:hover:text-secondary dark:text-secondary-foreground size-10 rounded-md text-2xl p-2" />
                         </Link>
                         )}


### PR DESCRIPTION
## Description

- Non sudo admins are no longer able to view settings button in mobile view
- Inbound hosts selection in mobile view is now scrollable and does not overflow

## UI Changes

- **fix(admin-role): non-sudo admin is not allowed to access settings button**
  - Non sudo admins are no longer able to view settings button in mobile view
- **style(inbound-hosts-selection): scrollable inbounds on mobile view**
  - Inbound hosts selection in mobile view is now scrollable and does not overflow

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.
