### PR TITLE
fix(entity-table): stacking view options and create button on filter for mobile

### DIFF
--- a/dashboard/src/features/entity-table/components/table-filtering.tsx
+++ b/dashboard/src/features/entity-table/components/table-filtering.tsx
@@ -16,7 +16,7 @@ export const TableFiltering: FC<TableFilteringProps> = () => {
             placeholder={t('table.filter-placeholder', { name: filtering.column })}
             value={filtering.columnFilters}
             onChange={(e) => filtering.setColumnFilters(e.target.value)}
-            className="max-w-sm w-[8rem] md:w-[20rem]"
+            className=" w-full md:w-[20rem]"
         />
     );
 }

--- a/dashboard/src/features/entity-table/entity-table.tsx
+++ b/dashboard/src/features/entity-table/entity-table.tsx
@@ -88,14 +88,16 @@ export function EntityTable<T>({
     return (
         <EntityTableContext.Provider value={contextValue}>
             <div className="flex flex-col">
-                <div className="flex items-center py-4">
+                <div className="flex flex-col md:flex-row-reverse items-center py-4 gap-2 w-full">
+                    <div className="flex flex-row items-center w-full">
+                        <DataTableViewOptions table={table} />
+                        {onCreate && (
+                            <Button aria-label={`create-${entityKey}`} onClick={onCreate}>
+                                {t("create")}
+                            </Button>
+                        )}
+                    </div>
                     <TableFiltering />
-                    <DataTableViewOptions table={table} />
-                    {onCreate && (
-                        <Button aria-label={`create-${entityKey}`} onClick={onCreate}>
-                            {t("create")}
-                        </Button>
-                    )}
                 </div>
                 <div className="w-full rounded-md border">
                     <EntityDataTable columns={columns} onRowClick={onOpen} />


### PR DESCRIPTION
## Description

Resolving entity table filter field responsiveness and other table options for mobile users.

## UI Changes

- Entity table filter field and view options are stacked on top of each other to provide more resopnsive experience for mobile user

### Screenshots

![image](https://github.com/user-attachments/assets/e85d01e3-5266-423d-aa39-1cd5186852cb)


## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes #435
