### PR TITLE
fix(subscription): fix expire ts in subscription headers to avoid v2box crash

### DIFF
--- a/app/routes/subscription.py
+++ b/app/routes/subscription.py
@@ -40,7 +40,9 @@ def get_subscription_user_info(user: UserResponse) -> dict:
         "download": user.used_traffic,
         "total": user.data_limit,
         "expire": (
-            user.expire_date if user.expire_strategy == "fixed_date" else None
+            int(user.expire_date.timestamp())
+            if user.expire_strategy == "fixed_date"
+            else None
         ),
     }
 


### PR DESCRIPTION
## Description

expire should be timestamp instead of datetime in subscription headers.

## UI Changes

-
-

### Screenshots

## API Changes

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes

- #
- #

