### PR TITLE
fix(users-data-limit): metric conversion after type conversion

### DIFF
--- a/dashboard/src/features/users/types/schema.ts
+++ b/dashboard/src/features/users/types/schema.ts
@@ -5,9 +5,9 @@ export const UserSchema = z.object({
     username: z.string().min(1, { message: 'Username is required' }),
     note: z.string().nullable(),
     data_limit: z
-        .union([z.string().transform((str) => (Number(str) * DATA_LIMIT_METRIC)), z.number()])
+        .union([z.string().transform((str) => (Number(str))), z.number()])
         .refine(val => val >= 0, { message: 'The minimum number is 0' })
-        .transform((val) => Math.round(val) ?? 0)
+        .transform((val) => Math.round(val) * DATA_LIMIT_METRIC ?? 0)
         .nullable()
         .optional(),
     data_limit_reset_strategy: z

--- a/dashboard/src/features/users/types/schema.ts
+++ b/dashboard/src/features/users/types/schema.ts
@@ -7,7 +7,7 @@ export const UserSchema = z.object({
     data_limit: z
         .union([z.string().transform((str) => (Number(str))), z.number()])
         .refine(val => val >= 0, { message: 'The minimum number is 0' })
-        .transform((val) => Math.round(val) * DATA_LIMIT_METRIC ?? 0)
+        .transform((val) => (Math.round(val) ?? 0) * DATA_LIMIT_METRIC)
         .nullable()
         .optional(),
     data_limit_reset_strategy: z


### PR DESCRIPTION
## Description

Resolving editing a user with data limit may result in data
limit cast into bytes issue by reprioritizing metric conversion.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes #444

- #444
