### PR TITLE
feat(header-menu): including settings and admins page in menu for sudo admins in mobile view

### DIFF
--- a/dashboard/src/components/header/menu.tsx
+++ b/dashboard/src/components/header/menu.tsx
@@ -8,37 +8,65 @@ import {
     DropdownMenuGroup,
     Button,
 } from "@marzneshin/components";
+import { Link } from "@tanstack/react-router";
 import { FC } from 'react';
-import { MenuIcon } from "lucide-react";
+import { Settings, MenuIcon, ShieldCheck } from "lucide-react";
 import { LanguageSwitchMenu } from "@marzneshin/features/language-switch";
 import { ThemeToggle } from "@marzneshin/features/theme-switch";
-import { Logout } from "@marzneshin/features/auth";
+import { useAuth, Logout } from "@marzneshin/features/auth";
+import { useScreenBreakpoint } from "@marzneshin/hooks/use-screen-breakpoint";
+import { useTranslation } from "react-i18next";
 
-export const HeaderMenu: FC = () => (
-    <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-            <Button
-                variant="secondary"
-                className="bg-gray-800 text-secondary dark:hover:bg-secondary-foreground dark:hover:text-secondary dark:text-secondary-foreground"
-                size="icon"
-            >
-                <MenuIcon />
-            </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-            <DropdownMenuLabel>Menu</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-                <LanguageSwitchMenu />
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-                <ThemeToggle />
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem className="w-full">
-                <Logout />
-            </DropdownMenuItem>
-        </DropdownMenuContent>
-    </DropdownMenu >
-);
+export const HeaderMenu: FC = () => {
+
+    const isDesktop = useScreenBreakpoint("md");
+    const { isSudo } = useAuth();
+    const { t } = useTranslation();
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    variant="secondary"
+                    className="bg-gray-800 text-secondary dark:hover:bg-secondary-foreground dark:hover:text-secondary dark:text-secondary-foreground"
+                    size="icon"
+                >
+                    <MenuIcon />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+                <DropdownMenuLabel>Menu</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {(!isDesktop && isSudo()) && (
+                    <>
+                        <DropdownMenuItem className="w-full">
+                            <Link to="/settings" className="hstack gap-1 items-center justify-between w-full h-fit p-0">
+                                {t("settings")}
+                                <Settings className="size-4" />
+                            </Link>
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem className="w-full">
+                            <Link to="/admins" className="hstack gap-1 items-center justify-between w-full h-fit p-0" >
+                                {t("admins")}
+                                <ShieldCheck className="size-4" />
+                            </Link>
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                    </>
+                )}
+                <DropdownMenuItem className="w-full">
+                    <Logout />
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                    <LanguageSwitchMenu />
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                    <ThemeToggle />
+                </DropdownMenuGroup>
+            </DropdownMenuContent>
+        </DropdownMenu >
+    )
+};

--- a/dashboard/src/features/users/components/dialogs/mutation/sections/expiration-method/index.tsx
+++ b/dashboard/src/features/users/components/dialogs/mutation/sections/expiration-method/index.tsx
@@ -16,9 +16,7 @@ import {
 } from "@marzneshin/features/users/components/dialogs/mutation/fields";
 import { TabsList } from "@radix-ui/react-tabs";
 import { useTranslation } from "react-i18next";
-import {
-    useExpirationMethodTabs,
-} from "./use-expiration-method-tabs";
+import { useExpirationMethodTabs } from "./use-expiration-method-tabs";
 
 interface ExpirationMethodProps {
     entity: UserMutationType | null

--- a/dashboard/src/routes/_dashboard.tsx
+++ b/dashboard/src/routes/_dashboard.tsx
@@ -24,7 +24,6 @@ import { GithubRepo } from "@marzneshin/features/github-repo";
 import { CommandBox } from "@marzneshin/features/search-command";
 import { DashboardBottomMenu } from "@marzneshin/features/bottom-menu";
 import { VersionIndicator } from "@marzneshin/features/version-indicator";
-import { Settings } from "lucide-react";
 
 export const DashboardLayout = () => {
     const isDesktop = useScreenBreakpoint("md");
@@ -57,10 +56,6 @@ export const DashboardLayout = () => {
                 end={
                     <>
                         <GithubRepo variant={isDesktop ? "full" : "mini"} />
-                        {(!isDesktop && isSudo()) && (<Link to="/settings">
-                            <Settings className="bg-gray-800 text-secondary dark:hover:bg-secondary-foreground dark:hover:text-secondary dark:text-secondary-foreground size-10 rounded-md text-2xl p-2" />
-                        </Link>
-                        )}
                         <HeaderMenu />
                     </>
                 }


### PR DESCRIPTION
## Description

Providing admins page access for mobile view

## UI Changes

- Including settings and admins page in menu for sudo admins in mobile view

### Screenshots

## API Changes

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.
