### PR TITLE
style(dashboard-sidebar): uppercase sidebar group items

### DIFF
--- a/dashboard/src/components/sidebar/sidebar-group.tsx
+++ b/dashboard/src/components/sidebar/sidebar-group.tsx
@@ -1,6 +1,7 @@
 
 import { FC, PropsWithChildren } from "react"
 import { Label } from "@marzneshin/components"
+import { cn } from "@marzneshin/utils"
 import { useSidebarContext } from "./sidebar-provider";
 
 export interface SidebarGroupProps

--- a/dashboard/src/components/sidebar/sidebar-group.tsx
+++ b/dashboard/src/components/sidebar/sidebar-group.tsx
@@ -5,15 +5,15 @@ import { useSidebarContext } from "./sidebar-provider";
 
 export interface SidebarGroupProps
     extends PropsWithChildren {
-
+    className: string
 }
 
-export const SidebarGroup: FC<SidebarGroupProps> = ({ children }) => {
+export const SidebarGroup: FC<SidebarGroupProps> = ({ children, className }) => {
     const { collapsed } = useSidebarContext();
 
     if (!collapsed)
         return (
-            <Label className="text-gray-500 font-header">
+            <Label className={cn(className, "text-gray-500 font-header")}>
                 {children}
             </Label>
         )

--- a/dashboard/src/features/sidebar/sidebar.tsx
+++ b/dashboard/src/features/sidebar/sidebar.tsx
@@ -41,7 +41,7 @@ export const DashboardSidebar: FC<DashboardSidebarProps> = ({
                         <Sidebar.Body>
                             {Object.keys(sidebarItems).map((key) => (
                                 <div className="w-full" key={key}>
-                                    <Sidebar.Group>{key}</Sidebar.Group>
+                                    <Sidebar.Group className="uppercase">{key}</Sidebar.Group>
                                     {sidebarItems[key].map((item: SidebarItem) => (
                                         <Sidebar.Item
                                             variant={isCurrentRouteActive(item.to) ? "active" : "default"}


### PR DESCRIPTION
## Description

- Sidebar group labels are transformed into uppercase to improve visual hierarchy
