### PR TITLE
fix(stats): filter removed users from the count query

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -327,7 +327,7 @@ def get_users_count(
     expired: bool | None = None,
     data_limit_reached: bool | None = None,
 ):
-    query = db.query(User.id)
+    query = db.query(User.id).filter(User.removed == False)
     if admin:
         query = query.filter(User.admin_id == admin.id)
     if is_active:


### PR DESCRIPTION
## Description

Soft deleting users caused user stats to show wrong numbers. This just adds the filter to avoid removed users to be considered in the count.

### Screenshots

## API Changes

## Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes

- #467 


