### PR TITLE
fix(users-dialog): assign the default expiration strategy value

### DIFF
--- a/dashboard/src/components/form-fields/date.tsx
+++ b/dashboard/src/components/form-fields/date.tsx
@@ -1,10 +1,21 @@
-import { FC, useEffect, useState } from 'react';
-import { format } from 'date-fns';
-import { CalendarIcon } from '@radix-ui/react-icons';
-import { cn } from '@marzneshin/utils';
-import { useFormContext, FieldValues } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
-import { Popover, PopoverTrigger, FormControl, Button, Calendar, PopoverContent, FormLabel, FormItem, FormField, FormMessage } from '@marzneshin/components';
+import { type FC, useEffect, useState } from "react";
+import { format } from "date-fns";
+import { CalendarIcon } from "@radix-ui/react-icons";
+import { cn } from "@marzneshin/utils";
+import { useFormContext, type FieldValues } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import {
+    Popover,
+    PopoverTrigger,
+    FormControl,
+    Button,
+    Calendar,
+    PopoverContent,
+    FormLabel,
+    FormItem,
+    FormField,
+    FormMessage,
+} from "@marzneshin/components";
 
 interface DateFieldProps {
     name: keyof FieldValues;
@@ -20,13 +31,19 @@ function parseISODate(isoDateString: string | undefined): Date | undefined {
 export const DateField: FC<DateFieldProps> = ({ name, label }) => {
     const { t } = useTranslation();
     const form = useFormContext();
-    const [selectedDate, setSelectedDate] = useState<Date | undefined>(parseISODate(form.getValues(name)));
+    const [selectedDate, setSelectedDate] = useState<Date | undefined>(
+        parseISODate(form.getValues(name)),
+    );
 
     useEffect(() => {
         const newValue = selectedDate?.toISOString().slice(0, -5);
         const prevValue = form.getValues(name);
         if (newValue !== prevValue) {
-            form.setValue(name, newValue, { shouldValidate: true, shouldTouch: true });
+            form.setValue(name, newValue, {
+                shouldValidate: true,
+                shouldTouch: true,
+                shouldDirty: true,
+            });
         }
     }, [form, name, selectedDate]);
 
@@ -44,11 +61,11 @@ export const DateField: FC<DateFieldProps> = ({ name, label }) => {
                                     variant={"outline"}
                                     className={cn(
                                         "w-full pl-3 text-left font-normal",
-                                        !field.value && "text-muted-foreground"
+                                        !field.value && "text-muted-foreground",
                                     )}
                                 >
                                     {field.value ? (
-                                        format(field.value + 'Z', "PPP")
+                                        format(field.value + "Z", "PPP")
                                     ) : (
                                         <span>Pick a date</span>
                                     )}
@@ -64,9 +81,7 @@ export const DateField: FC<DateFieldProps> = ({ name, label }) => {
                                 onSelect={(date) => {
                                     setSelectedDate(date);
                                 }}
-                                disabled={(date) =>
-                                    date < new Date()
-                                }
+                                disabled={(date) => date < new Date()}
                                 initialFocus
                             />
                         </PopoverContent>

--- a/dashboard/src/features/users/components/dialogs/mutation/index.tsx
+++ b/dashboard/src/features/users/components/dialogs/mutation/index.tsx
@@ -16,11 +16,12 @@ import {
     useUsersCreationMutation,
     useUsersUpdateMutation,
     UserSchema,
-    UsernameField, type UserMutationType
+    UsernameField,
+    type UserMutationType,
 } from "@marzneshin/features/users";
 import { ServicesField } from "@marzneshin/features/services";
 import { NoteField } from "./fields";
-import { MutationDialogProps, useMutationDialog } from "@marzneshin/hooks";
+import { type MutationDialogProps, useMutationDialog } from "@marzneshin/hooks";
 import { DataLimitFields, ExpirationMethodFields } from "./sections";
 
 export const UsersMutationDialog: FC<MutationDialogProps<UserMutationType>> = ({
@@ -60,7 +61,7 @@ export const UsersMutationDialog: FC<MutationDialogProps<UserMutationType>> = ({
                         </DialogTitle>
                     </DialogHeader>
                     <Form {...form}>
-                        <form onSubmit={handleSubmit} >
+                        <form onSubmit={handleSubmit}>
                             <div className="flex-col grid-cols-2 gap-2 sm:flex md:grid h-full">
                                 <div className="space-y-3">
                                     <UsernameField disabled={!!entity?.username} />

--- a/dashboard/src/features/users/components/dialogs/mutation/index.tsx
+++ b/dashboard/src/features/users/components/dialogs/mutation/index.tsx
@@ -29,12 +29,17 @@ export const UsersMutationDialog: FC<MutationDialogProps<UserMutationType>> = ({
     onClose,
 }) => {
     const { t } = useTranslation();
-    const defaultValue = useMemo(() => ({
-        service_ids: [],
-        username: "",
-        data_limit_reset_strategy: "no_reset",
-        note: "",
-    }), [])
+    const defaultValue = useMemo(
+        () => ({
+            service_ids: [],
+            username: "",
+            data_limit_reset_strategy: "no_reset",
+            note: "",
+            expire_date: "",
+            expire_strategy: "fixed_date",
+        }),
+        [],
+    );
 
     const { open, onOpenChange, form, handleSubmit } = useMutationDialog({
         entity,


### PR DESCRIPTION
## Description

Assigne the default expiration strategy value, so the
schema is valid on the first component mount.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes #482
