### PR TITLE
feat(users-settings): adding created at and online at with time

### DIFF
--- a/dashboard/biome.json
+++ b/dashboard/biome.json
@@ -2,7 +2,7 @@
   "$schema": "https://biomejs.dev/schemas/1.6.4/schema.json",
   "formatter": {
     "indentStyle": "space",
-    "indentSize": 2
+    "indentSize": 4
   },
   "json": {
     "formatter": {

--- a/dashboard/public/locales/en.json
+++ b/dashboard/public/locales/en.json
@@ -165,6 +165,7 @@
     },
     "users": {
       "created_at": "Created At",
+      "no_use": "No Use",
       "data_limit_reached": "Data Limit Reached",
       "note-placeholder": "Additional information about user",
       "data_limit": "Data Limit",

--- a/dashboard/public/locales/en.json
+++ b/dashboard/public/locales/en.json
@@ -164,6 +164,7 @@
       }
     },
     "users": {
+      "created_at": "Created At",
       "data_limit_reached": "Data Limit Reached",
       "note-placeholder": "Additional information about user",
       "data_limit": "Data Limit",

--- a/dashboard/src/components/info-table/date-table-row.tsx
+++ b/dashboard/src/components/info-table/date-table-row.tsx
@@ -1,14 +1,15 @@
-import { FC } from "react";
+import type { FC } from "react";
 import { TableRowWithCell } from "./table-row-with-cell";
 import { format, isValid } from "date-fns";
 
-export const DateTableRow: FC<{ label: string; date?: Date | null | string }> = ({
-    label,
-    date,
-}) => {
+export const DateTableRow: FC<{
+    label: string;
+    withTime?: boolean;
+    date?: Date | null | string;
+}> = ({ label, date, withTime = false }) => {
     let formattedDate = "";
     if (date && isValid(new Date(date))) {
-        formattedDate = format(date, "PPP");
+        formattedDate = format(date, withTime ? "Ppp" : "P");
     }
     return <TableRowWithCell label={label} value={formattedDate} />;
 };

--- a/dashboard/src/components/info-table/date-table-row.tsx
+++ b/dashboard/src/components/info-table/date-table-row.tsx
@@ -9,8 +9,7 @@ export const DateTableRow: FC<{
 }> = ({ label, date, withTime = false }) => {
     let formattedDate = "";
     if (date && isValid(new Date(date))) {
-        const utcDate = new Date(date);
-        formattedDate = format(new Date(utcDate.toLocaleString()), withTime ? "Ppp" : "P");
+        formattedDate = format(new Date(date + "Z"), withTime ? "Ppp" : "P");
     }
     return <TableRowWithCell label={label} value={formattedDate} />;
 };

--- a/dashboard/src/components/info-table/date-table-row.tsx
+++ b/dashboard/src/components/info-table/date-table-row.tsx
@@ -9,7 +9,7 @@ export const DateTableRow: FC<{
 }> = ({ label, date, withTime = false }) => {
     let formattedDate = "";
     if (date && isValid(new Date(date))) {
-        formattedDate = format(date, withTime ? "Ppp" : "P");
-    }
+        formattedDate = format(new Date(date), withTime ? "Ppp" : "P");
+    }        
     return <TableRowWithCell label={label} value={formattedDate} />;
 };

--- a/dashboard/src/components/info-table/date-table-row.tsx
+++ b/dashboard/src/components/info-table/date-table-row.tsx
@@ -9,7 +9,8 @@ export const DateTableRow: FC<{
 }> = ({ label, date, withTime = false }) => {
     let formattedDate = "";
     if (date && isValid(new Date(date))) {
-        formattedDate = format(new Date(date), withTime ? "Ppp" : "P");
-    }        
+        const utcDate = new Date(date);
+        formattedDate = format(new Date(utcDate.toLocaleString()), withTime ? "Ppp" : "P");
+    }
     return <TableRowWithCell label={label} value={formattedDate} />;
 };

--- a/dashboard/src/components/settings-dialog/index.tsx
+++ b/dashboard/src/components/settings-dialog/index.tsx
@@ -32,7 +32,7 @@ export const SettingsDialog: FC<SettingsDialogProps & PropsWithChildren> = ({
         <SheetHeader>
           <SheetTitle>{t("settings")}</SheetTitle>
         </SheetHeader>
-        <ScrollArea className="flex flex-col gap-4 h-full">
+        <ScrollArea className="flex flex-col gap-4 h-full max-h-[40rem]">
           {children}
         </ScrollArea>
       </SheetContent>

--- a/dashboard/src/features/users/components/dialogs/settings/user-info/table.tsx
+++ b/dashboard/src/features/users/components/dialogs/settings/user-info/table.tsx
@@ -8,7 +8,7 @@ import {
     TableRowWithCell,
     DateTableRow,
 } from "@marzneshin/components";
-import { FC } from "react";
+import type { FC } from "react";
 import {
     type UserProp,
     UserEnabledPill,
@@ -21,9 +21,7 @@ import { useTranslation } from "react-i18next";
 
 export const UserInfoTable: FC<UserProp> = ({ user: entity }) => {
     const { t } = useTranslation();
-    const expireDate = entity.expire_date
-        ? new Date(entity.expire_date)
-        : null;
+    const expireDate = entity.expire_date ? new Date(entity.expire_date) : null;
 
     return (
         <Card>
@@ -50,32 +48,37 @@ export const UserInfoTable: FC<UserProp> = ({ user: entity }) => {
                             label={t("expired")}
                             value={<UserExpiredPill user={entity} />}
                         />
-                        {{
-                            fixed_date: (
-                                <DateTableRow
-                                    label={t("page.users.expire_date")}
-                                    date={expireDate}
-                                />
-                            ),
-                            start_on_first_use: (
-                                <>
-                                    <TableRowWithCell
-                                        label={t("page.users.usage_duration")}
-                                        value={(entity.usage_duration ? entity.usage_duration : 0) / 86400}
-                                    />
+                        {
+                            {
+                                fixed_date: (
                                     <DateTableRow
-                                        label={t("page.users.activation_deadline")}
-                                        date={entity.activation_deadline}
+                                        label={t("page.users.expire_date")}
+                                        date={expireDate}
                                     />
-                                </>
-                            ),
-                            never: (
-                                <TableRowWithCell
-                                    label={t("page.users.expire_method")}
-                                    value={t('never')}
-                                />
-                            )
-                        }[entity.expire_strategy]}
+                                ),
+                                start_on_first_use: (
+                                    <>
+                                        <TableRowWithCell
+                                            label={t("page.users.usage_duration")}
+                                            value={
+                                                (entity.usage_duration ? entity.usage_duration : 0) /
+                                                86400
+                                            }
+                                        />
+                                        <DateTableRow
+                                            label={t("page.users.activation_deadline")}
+                                            date={entity.activation_deadline}
+                                        />
+                                    </>
+                                ),
+                                never: (
+                                    <TableRowWithCell
+                                        label={t("page.users.expire_method")}
+                                        value={t("never")}
+                                    />
+                                ),
+                            }[entity.expire_strategy]
+                        }
 
                         <TableRowWithCell
                             label={t("page.users.used_traffic")}

--- a/dashboard/src/features/users/components/dialogs/settings/user-info/table.tsx
+++ b/dashboard/src/features/users/components/dialogs/settings/user-info/table.tsx
@@ -7,6 +7,7 @@ import {
     TableBody,
     TableRowWithCell,
     DateTableRow,
+    Badge
 } from "@marzneshin/components";
 import type { FC } from "react";
 import {
@@ -84,11 +85,18 @@ export const UserInfoTable: FC<UserProp> = ({ user: entity }) => {
                             label={t("page.users.used_traffic")}
                             value={<UserUsedTraffic user={entity} />}
                         />
-                        <DateTableRow
-                            label={t("page.users.online_at")}
-                            date={entity.online_at}
-                            withTime
-                        />
+                        {entity.online_at ? (
+                            <DateTableRow
+                                label={t("page.users.online_at")}
+                                date={entity.online_at}
+                                withTime
+                            />
+                        ) : (
+                            <TableRowWithCell
+                                label={t("page.users.online_at")}
+                                value={<Badge>{t("page.users.no_use")}</Badge>}
+                            />
+                        )}
                         <DateTableRow
                             label={t("page.users.created_at")}
                             date={entity.created_at}

--- a/dashboard/src/features/users/components/dialogs/settings/user-info/table.tsx
+++ b/dashboard/src/features/users/components/dialogs/settings/user-info/table.tsx
@@ -84,6 +84,7 @@ export const UserInfoTable: FC<UserProp> = ({ user: entity }) => {
                         <DateTableRow
                             label={t("page.users.online_at")}
                             date={entity.online_at}
+                            withTime
                         />
                         <TableRowWithCell label={t("note")} value={entity.note} />
                     </TableBody>

--- a/dashboard/src/features/users/components/dialogs/settings/user-info/table.tsx
+++ b/dashboard/src/features/users/components/dialogs/settings/user-info/table.tsx
@@ -86,6 +86,10 @@ export const UserInfoTable: FC<UserProp> = ({ user: entity }) => {
                             date={entity.online_at}
                             withTime
                         />
+                        <DateTableRow
+                            label={t("page.users.created_at")}
+                            date={entity.created_at}
+                        />
                         <TableRowWithCell label={t("note")} value={entity.note} />
                     </TableBody>
                 </Table>

--- a/dashboard/src/features/users/components/tables/users/columns.tsx
+++ b/dashboard/src/features/users/components/tables/users/columns.tsx
@@ -15,8 +15,10 @@ import {
     NoPropogationButton,
 } from "@marzneshin/components";
 import { LinkIcon } from "lucide-react";
+import { Badge } from "@marzneshin/components";
 import { getSubscriptionLink } from "@marzneshin/utils";
 import type { ColumnActions, ColumnDefWithSudoRole } from "@marzneshin/features/entity-table";
+import { format } from "date-fns";
 
 export const columns = (actions: ColumnActions<UserType>): ColumnDefWithSudoRole<UserType>[] => [
     {
@@ -29,7 +31,7 @@ export const columns = (actions: ColumnActions<UserType>): ColumnDefWithSudoRole
                 <OnlineStatus user={row.original} /> {row.original.username}
             </div>
         ),
-    }, 
+    },
     {
         accessorKey: "activated",
         enableSorting: false,
@@ -82,6 +84,16 @@ export const columns = (actions: ColumnActions<UserType>): ColumnDefWithSudoRole
             />
         ),
         cell: ({ row }) => <UserExpirationValue user={row.original} />,
+    },
+    {
+        accessorKey: "online_at",
+        header: ({ column }) => (
+            <DataTableColumnHeader
+                title={i18n.t("page.users.online_at")}
+                column={column}
+            />
+        ),
+        cell: ({ row }) => row.original.online_at ? format(new Date(row.original.online_at), "Ppp") : <Badge>{i18n.t("page.users.no_use")}</Badge>,
     },
     {
         id: "actions",

--- a/dashboard/src/features/users/components/tables/users/columns.tsx
+++ b/dashboard/src/features/users/components/tables/users/columns.tsx
@@ -15,10 +15,8 @@ import {
     NoPropogationButton,
 } from "@marzneshin/components";
 import { LinkIcon } from "lucide-react";
-import { Badge } from "@marzneshin/components";
 import { getSubscriptionLink } from "@marzneshin/utils";
 import type { ColumnActions, ColumnDefWithSudoRole } from "@marzneshin/features/entity-table";
-import { format } from "date-fns";
 
 export const columns = (actions: ColumnActions<UserType>): ColumnDefWithSudoRole<UserType>[] => [
     {
@@ -84,16 +82,6 @@ export const columns = (actions: ColumnActions<UserType>): ColumnDefWithSudoRole
             />
         ),
         cell: ({ row }) => <UserExpirationValue user={row.original} />,
-    },
-    {
-        accessorKey: "online_at",
-        header: ({ column }) => (
-            <DataTableColumnHeader
-                title={i18n.t("page.users.online_at")}
-                column={column}
-            />
-        ),
-        cell: ({ row }) => row.original.online_at ? format(new Date(row.original.online_at), "Ppp") : <Badge>{i18n.t("page.users.no_use")}</Badge>,
     },
     {
         id: "actions",


### PR DESCRIPTION
## Description

Adding new paramaters and improving the view of existing paramaters in user settings info section.

## UI Changes

- Created At info
- Adding time to the online at user info row
- New column for users table which indicates  when the user was online, it shows "No Uses" where the user was never online.

### Screenshots

![image](https://github.com/user-attachments/assets/54dcc5f9-1263-46ee-a173-3c26864b7a7b)
![image](https://github.com/user-attachments/assets/78fdcc3f-5408-4f59-8ed5-33964028001e)


## Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes #477 #452 

- #477
- #452 

