### PR TITLE
fix(inbounds-popover): lowering the size of inbounds popover

### DIFF
--- a/dashboard/src/features/entity-table/components/sidebar-entity-popover.tsx
+++ b/dashboard/src/features/entity-table/components/sidebar-entity-popover.tsx
@@ -25,7 +25,7 @@ export const SidebarEntityTablePopover: FC<SidebarEntityTablePopoverProps> = ({
                 {buttonChild}
             </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-80 max-h-100 p-0">
+        <PopoverContent className="w-80 p-0">
             <SidebarEntitySelection />
         </PopoverContent>
     </Popover>

--- a/dashboard/src/features/entity-table/components/sidebar-entity-selection.tsx
+++ b/dashboard/src/features/entity-table/components/sidebar-entity-selection.tsx
@@ -3,6 +3,7 @@ import {
     Table, TableHeader, TableRow, TableBody, TableHead,
     ScrollArea, Button,
 } from "@marzneshin/components";
+import { useScreenBreakpoint } from "@marzneshin/hooks";
 import { cn } from "@marzneshin/utils";
 import {
     SidebarEntityCard,
@@ -21,8 +22,9 @@ export const SidebarEntitySelection = () => {
         sidebarCardProps,
     } = useSidebarEntityTableContext()
     const { table } = useEntityTableContext()
+    const isDesktop = useScreenBreakpoint("md");
 
-    const scrollBarHeight = table.getState().pagination.pageSize <= 10 ? "max-h-[45rem]" : "max-h-full"
+    const scrollBarHeight = (table.getState().pagination.pageSize <= 10 && isDesktop) ? "max-h-[45rem]" : "max-h-[20rem]"
     const { t } = useTranslation();
 
     return (


### PR DESCRIPTION
## Description

The inbound popover content size is lower so the
user can easily select without scrolling down the entire page.

### Screenshots

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests (stories, interaction tests, unit tests, e2e tests) to cover my changes.
- [ ] I have added tests to cover my changes.

## Related Issues

Closes #480

- #480
