### PR TITLE
fix(settings-dialog-scroll): determining the size of screen for smaller vertical size with less bottom gap

### DIFF
--- a/dashboard/src/components/settings-dialog/index.tsx
+++ b/dashboard/src/components/settings-dialog/index.tsx
@@ -32,7 +32,7 @@ export const SettingsDialog: FC<SettingsDialogProps & PropsWithChildren> = ({
         <SheetHeader>
           <SheetTitle>{t("settings")}</SheetTitle>
         </SheetHeader>
-        <ScrollArea className="flex flex-col gap-4 h-full max-h-[40rem]">
+        <ScrollArea className="flex flex-col gap-4 h-[calc(100vh-100px)] max-h-full">
           {children}
         </ScrollArea>
       </SheetContent>


### PR DESCRIPTION
## Description

Fixing the vertical undersize of the settings dialog.
